### PR TITLE
fix: logic errors (some/none cases)

### DIFF
--- a/src/data/quiz-templates.json
+++ b/src/data/quiz-templates.json
@@ -63,10 +63,7 @@
         { "type": "none", "subject": "X", "object": "Y" },
         { "type": "some", "subject": "Y", "object": "Z" }
       ],
-      "correct": [
-        { "type": "unknown", "subject": "X", "object": "Z" },
-        { "type": "unknown", "subject": "Z", "object": "X" }
-      ]
+      "correct": [{ "type": "some_none", "subject": "Z", "object": "X" }]
     },
     {
       "statements": [
@@ -215,10 +212,7 @@
         { "type": "none", "subject": "X", "object": "Y" },
         { "type": "some", "subject": "X", "object": "Z" }
       ],
-      "correct": [
-        { "type": "unknown", "subject": "Y", "object": "Z" },
-        { "type": "unknown", "subject": "Z", "object": "Y" }
-      ]
+      "correct": [{ "type": "some_none", "subject": "Z", "object": "Y" }]
     },
     {
       "statements": [
@@ -245,10 +239,7 @@
         { "type": "some", "subject": "X", "object": "Y" },
         { "type": "none", "subject": "X", "object": "Z" }
       ],
-      "correct": [
-        { "type": "unknown", "subject": "Y", "object": "Z" },
-        { "type": "unknown", "subject": "Z", "object": "Y" }
-      ]
+      "correct": [{ "type": "some_none", "subject": "Y", "object": "Z" }]
     },
     {
       "statements": [
@@ -370,10 +361,7 @@
         { "type": "none", "subject": "Y", "object": "X" },
         { "type": "some", "subject": "Z", "object": "X" }
       ],
-      "correct": [
-        { "type": "unknown", "subject": "Y", "object": "Z" },
-        { "type": "unknown", "subject": "Z", "object": "Y" }
-      ]
+      "correct": [{ "type": "some_none", "subject": "Z", "object": "Y" }]
     },
     {
       "statements": [


### PR DESCRIPTION
Explanation: https://www.studymed.at/backend/lernen/inhalt/url/die-kombination-einer-alle-sind-keinemit-einer-einige-sind-aussage

In short: The statements are both interchangeable (subjects and objects in `none` and `some` can be changed and are still valid). That's why all `some`/`none` cases have to have the same correct case.

Here you have a diagram explaining why the correct statement **cannot** be interchanged though!

<img width="2599" height="2463" alt="image" src="https://github.com/user-attachments/assets/c30b2035-19b0-43c3-9e84-9bc04b8825d4" />

If you are now wondering why I only had to change the wrong logic in 4 places instead of 6 possible combinations: It was already correct in 2/6 (resolving inconsistency).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved ambiguous answers in four quiz templates by consolidating multiple “correct” options into a single definitive answer, improving scoring consistency.

* **Refactor**
  * Standardized answer format across the affected quizzes to use a single consolidated correct option for clarity and uniform behavior.

* **Documentation**
  * Updated quiz data to reflect the clarified correct answers, reducing confusion for learners and making outcomes more predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->